### PR TITLE
Move middleware processing inside of message handlers so errors are handled correctly

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -45,6 +45,7 @@ group :tests_and_checks, halt_on_failure: true do
   group 'features' do
     guard('cucumber',
           all_on_start: false,
+          all_after_pass: false,
           cmd: "bundle exec cucumber --no-profile --color --strict --tag @all_adapters,@#{BrokerConfig.current_adapter} --tag ~@wip",
           cmd_additional_args: '--format pretty --tag ~@slow',
           run_all: {

--- a/features/middleware/middleware_error_handling.feature
+++ b/features/middleware/middleware_error_handling.feature
@@ -1,0 +1,120 @@
+@bunny
+Feature: Middleware Error Handling
+
+  If a middleware raises an error, we need to ensure it is handled properly.
+
+  Background:
+    Given I am connected to the broker
+    And I have a destination :middleware_queue with no messages on it
+    And I have a middleware class
+    """ruby
+    class ErrorMiddleware < MessageDriver::Middleware::Base
+      # def on_publish(body, headers, properties)
+      #   [body, headers, properties]
+      # end
+
+      def on_consume(body, headers, properties)
+        if body.start_with? 'error'
+          raise "error trying to consume! #{body}"
+        else
+          [body, headers, properties]
+        end
+      end
+    end
+    """
+    And I append middleware "ErrorMiddleware" to :middleware_queue
+    And I have a destination :dest_queue with no messages on it
+
+  @in_memory
+  Scenario: Publishing a message
+    Given I have a middleware class
+    """ruby
+    class PublishErrorMiddleware < MessageDriver::Middleware::Base
+      def on_publish(body, headers, properties)
+        raise 'error trying to publish!'
+      end
+
+      def on_consume(body, headers, properties)
+        [body, headers, properties]
+      end
+    end
+    """
+    And I append middleware "PublishErrorMiddleware" to :middleware_queue
+
+    When I execute the following code
+    """ruby
+    MessageDriver::Client.publish(:middleware_queue, 'middleware error test')
+    """
+    Then I expect it to raise "error trying to publish!"
+    And I expect to find no message on :middleware_queue
+
+
+  Scenario: Consuming a message with an auto-ack consumer
+    Given I create a subscription
+    """ruby
+    MessageDriver::Client.subscribe_with(:middleware_queue) do |message|
+      MessageDriver::Client.publish(:dest_queue, message.body)
+    end
+    """
+
+    When I send the following message to :middleware_queue
+      | body           |
+      | Test Message 1 |
+      | error message  |
+      | Test Message 2 |
+    And I let the subscription process
+
+    Then I expect to find the following 2 messages on :dest_queue
+      | body           |
+      | Test Message 1 |
+      | Test Message 2 |
+    And I expect to find the following message on :middleware_queue
+      | body          |
+      | error message |
+
+  Scenario: Consuming with a manual ack consumer
+    Given I create a subscription
+    """ruby
+    MessageDriver::Client.subscribe_with(:middleware_queue, ack: :manual) do |message|
+      MessageDriver::Client.publish(:dest_queue, message.body)
+      message.ack
+    end
+    """
+
+    When I send the following message to :middleware_queue
+      | body           |
+      | Test Message 1 |
+      | error message  |
+      | Test Message 2 |
+    And I let the subscription process
+
+    Then I expect to find the following 2 messages on :dest_queue
+      | body           |
+      | Test Message 1 |
+      | Test Message 2 |
+    And I expect to find the following message on :middleware_queue
+      | body          |
+      | error message |
+
+  Scenario: Consuming with a transactional ack consumer
+    Given I create a subscription
+    """ruby
+    MessageDriver::Client.subscribe_with(:middleware_queue, ack: :transactional) do |message|
+      MessageDriver::Client.publish(:dest_queue, message.body)
+    end
+    """
+
+    When I send the following message to :middleware_queue
+      | body           |
+      | Test Message 1 |
+      | error message  |
+      | Test Message 2 |
+    And I let the subscription process
+
+    Then I expect to find the following 2 messages on :dest_queue
+      | body           |
+      | Test Message 1 |
+      | Test Message 2 |
+    And I expect to find the following message on :middleware_queue
+      | body          |
+      | error message |

--- a/lib/message_driver/middleware/middleware_stack.rb
+++ b/lib/message_driver/middleware/middleware_stack.rb
@@ -33,7 +33,7 @@ module MessageDriver
       end
 
       def on_consume(body, headers, properties)
-        @middlewares.reverse.reduce([body, headers, properties]) do |args, middleware|
+        @middlewares.reverse_each.reduce([body, headers, properties]) do |args, middleware|
           middleware.on_consume(*args)
         end
       end


### PR DESCRIPTION
Fixes #35 