### PR TITLE
Handle edge case for confirm_and_wait transactions in bunny adapter

### DIFF
--- a/lib/message_driver/adapters/bunny_adapter.rb
+++ b/lib/message_driver/adapters/bunny_adapter.rb
@@ -341,7 +341,7 @@ module MessageDriver
           end
           begin
             if @in_confirms_transaction
-              @channel.wait_for_confirms unless @rollback_only || @channel.nil?
+              @channel.wait_for_confirms unless @rollback_only || @channel.nil? || !@channel.using_publisher_confirms?
             elsif is_transactional? && valid? && !@need_channel_reset && @require_commit
               handle_errors do
                 if @rollback_only


### PR DESCRIPTION
If no messages have been sent, and thus the channel hasn't been put into
publisher_acknowlegements mode, don't ask the channel to
wait_for_confirms on transaction commit.

Fixes #39